### PR TITLE
Change default time to be today/15 weeks from today

### DIFF
--- a/backend/app/app/core/config.py
+++ b/backend/app/app/core/config.py
@@ -29,8 +29,8 @@ class Settings(BaseSettings):
     BASE_DIR: str = os.path.dirname(os.path.dirname(__file__))
 
     # Custom app settings
-    DEFAULT_CLASS_START_DATE: datetime.date = datetime.date(year=2021, month=9, day=7)
-    DEFAULT_CLASS_END_DATE: datetime.date = datetime.date(year=2021, month=12, day=15)
+    DEFAULT_CLASS_START_DATE: datetime.date = datetime.date.today()
+    DEFAULT_CLASS_END_DATE: DEFAULT_CLASS_START_DATE + datetime.timedelta(weeks=15)
 
     # Google config info
     GOOGLE_CLIENT_ID: str


### PR DESCRIPTION
The default was an arbitrary day, which was annoying. During the spring semesters the end date should be 16 weeks after the start date because of spring break in the middle. Who cares tho. I did not run tests locally because I don't know how to do that