### PR TITLE
Feat/date

### DIFF
--- a/backend/app/app/calendar_utils/fetch_date.py
+++ b/backend/app/app/calendar_utils/fetch_date.py
@@ -1,0 +1,56 @@
+import datetime
+import json
+import logging
+from typing import Any, Dict
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+def fetch_current_term_from_api() -> Dict[str, Any] :
+    """Creates a list of date objects gathered from the public api
+
+    Returns:
+        DatesResponse: Dictionary containing the list of date objects and other
+                         information
+    """
+    DEFAULT_CLASS_START_DATE = datetime.date.today()
+    DEFAULT_CLASS_END_DATE = DEFAULT_CLASS_START_DATE + datetime.timedelta(weeks=15)
+
+    try:
+        API_URL = 'https://terms.umn.edu/umntc/ugrd/soonest/today'
+        response = requests.get(API_URL, timeout=5)
+
+    except requests.Timeout:
+        logger.exception(f"Request timed out")
+        return {
+            "start_date": DEFAULT_CLASS_START_DATE,
+            "end_date": DEFAULT_CLASS_END_DATE,
+            "extracted_date": False,
+            "message": f"Request timed out",
+        }
+
+    except Exception as e:
+        logger.exception(f"An error occurred: {e}")
+        return {
+            "start_date": DEFAULT_CLASS_START_DATE,
+            "end_date": DEFAULT_CLASS_END_DATE,
+            "extracted_date": False,
+            "message": f"Could not get dates: {e}",
+        }
+    
+    json_content = response.text
+
+    # Parse the JSON content into a Python object
+    data = json.loads(json_content)
+
+    # Access the attributes of the object
+    # term_name = data['data'][0]['attributes']['name']
+    start_date = data['data'][0]['attributes']['begin-date']
+    end_date = data['data'][0]['attributes']['end-date']
+    return {
+        "start_date": start_date,
+        "end_date": end_date,
+        "extracted_date": True,
+        "message": "Successfully extracted classes",
+    }

--- a/backend/app/app/core/config.py
+++ b/backend/app/app/core/config.py
@@ -3,6 +3,7 @@ import os
 import secrets
 from typing import Any, Dict, List
 
+from app.calendar_utils.fetch_date import fetch_current_term_from_api
 from dotenv import load_dotenv
 from pydantic import AnyHttpUrl, BaseModel, BaseSettings, EmailStr
 from pydantic.tools import parse_obj_as
@@ -29,8 +30,9 @@ class Settings(BaseSettings):
     BASE_DIR: str = os.path.dirname(os.path.dirname(__file__))
 
     # Custom app settings
-    DEFAULT_CLASS_START_DATE: datetime.date = datetime.date(year=2021, month=9, day=7)
-    DEFAULT_CLASS_END_DATE: datetime.date = datetime.date(year=2021, month=12, day=15)
+    DEFAULT_CLASS_DATES = fetch_current_term_from_api()
+    DEFAULT_CLASS_START_DATE: datetime.date = DEFAULT_CLASS_DATES["start_date"]
+    DEFAULT_CLASS_END_DATE: datetime.date = DEFAULT_CLASS_DATES["end_date"]
 
     # Google config info
     GOOGLE_CLIENT_ID: str

--- a/backend/app/app/tests/calendar_utils/test_fetch_date.py
+++ b/backend/app/app/tests/calendar_utils/test_fetch_date.py
@@ -1,0 +1,17 @@
+import datetime
+
+from app.calendar_utils.fetch_date import fetch_current_term_from_api
+from app.core.config import settings
+from app.tests.utils.utils import load_class_html_str, load_classes_true_json
+
+
+def test_fetch_current_term_from_api() -> None:
+    """Test to ensure this function could fetch the date properly instead of default value"""
+    results = fetch_current_term_from_api()
+
+    today = datetime.date.today()
+
+    assert results["extracted_date"]
+    assert results["start_date"] != today and results["end_date"] != today + datetime.timedelta(weeks=15)
+    assert settings.DEFAULT_CLASS_START_DATE == results["start_date"]
+    assert settings.DEFAULT_CLASS_END_DATE == results["end_date"]


### PR DESCRIPTION
For issue mentioned about the arbitrary date display. I used the public api in umn to solve this problem. The api will return a json file with the current semester's basic information. I think this mode will authentically solve this problem. 
Except that, thanks to the previous PR, I followed its convention to design a backup plan to return default date. 
I also added some unit test for this function, but it is realistic and cannot solve the edge case(if today is the begin of the current semester and the duration of this semester is 15 weeks).
Overall, I believe this will improve this plugin on the date feature.